### PR TITLE
Feature/prep conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ target_include_directories(light_pcapng PUBLIC "include")
 
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(light_pcapng PRIVATE LIGHT_EXPORTS=1)
-  target_compile_definitions(light_pcapng PUBLIC LIGHT_IMPORTS=1) 
+  target_compile_definitions(light_pcapng PUBLIC LIGHT_IMPORTS=1)
 endif()
 
 # ZSTD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ file(GLOB LIGHT_SOURCES src/*.c)
 add_library(light_pcapng ${LIGHT_SOURCES})
 
 target_include_directories(light_pcapng PUBLIC "include")
+# Export API symbols when the library is created
+
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(light_pcapng PRIVATE LIGHT_EXPORTS=1)
+  target_compile_definitions(light_pcapng PUBLIC LIGHT_IMPORTS=1) 
+endif()
 
 # ZSTD
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,21 +25,30 @@ endif()
 
 file(GLOB LIGHT_SOURCES src/*.c)
 
-add_library(light_pcapng SHARED ${LIGHT_SOURCES})
-add_library(light_pcapng_static STATIC ${LIGHT_SOURCES})
+add_library(light_pcapng ${LIGHT_SOURCES})
 
 target_include_directories(light_pcapng PUBLIC "include")
-target_include_directories(light_pcapng_static PUBLIC "include")
 
 # ZSTD
 
 option(LIGHT_USE_ZSTD "Compile with ZSTD support" ON)
 
 if(LIGHT_USE_ZSTD)
-    include(cmake/zstd.cmake)
+    # Try to find zstd in the cmake search path
+    find_package(zstd QUIET)
+    if (zstd_FOUND)
+        # zstd was already found, so we don't resolve our dependency by ourself
+        set(light_zstd_dependency_name zstd::zstd)
+    else()
+        include(cmake/zstd.cmake)
+        if (BUILD_SHARED_LIBS)
+          set(light_zstd_dependency_name libzstd_shared)
+        else()
+          set(light_zstd_dependency_name libzstd_static)
+        endif()
+    endif()
     add_definitions(-DUSE_ZSTD)
-    target_link_libraries(light_pcapng libzstd_shared)
-    target_link_libraries(light_pcapng_static libzstd_static)
+    target_link_libraries(light_pcapng ${light_zstd_dependency_name})
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
@@ -50,10 +59,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     # We will make it even more strict in the future
     if(MSVC)
       target_compile_options(light_pcapng PRIVATE /W4)
-      target_compile_options(light_pcapng_static PRIVATE /W4)
     else()
       target_compile_options(light_pcapng PRIVATE -Werror)
-      target_compile_options(light_pcapng_static PRIVATE -Werror)
     endif()
 endif()
 

--- a/include/light_export.h
+++ b/include/light_export.h
@@ -7,8 +7,8 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -23,11 +23,11 @@
 
 /* =====   LIGHT_API : control library symbols visibility   ===== */
 #ifndef LIGHT_VISIBILITY
-#  if defined(__GNUC__) && (__GNUC__ >= 4)
-#    define LIGHT_VISIBILITY __attribute__ ((visibility ("default")))
-#  else
-#    define LIGHT_VISIBILITY
-#  endif
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+#define LIGHT_VISIBILITY __attribute__((visibility("default")))
+#else
+#define LIGHT_VISIBILITY
+#endif
 #endif
 
 /* API call convention*/
@@ -38,37 +38,19 @@
 #endif
 
 #if defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 1)
-# ifdef _MSC_VER
-#   define LIGHT_API __declspec(dllexport) LIGHT_VISIBILITY
-# else 
-#   define LIGHT_API LIGHT_VISIBILITY
-# endif
+#ifdef _MSC_VER
+#define LIGHT_API __declspec(dllexport) LIGHT_VISIBILITY
+#else
+#define LIGHT_API LIGHT_VISIBILITY
+#endif
 #elif defined LIGHT_IMPORTS && (LIGHT_IMPORTS == 1)
-# ifdef _MSC_VER
-#   define LIGHT_API __declspec(dllimport) LIGHT_VISIBILITY
-# else 
-#   define LIGHT_API LIGHT_VISIBILITY
-# endif
-#else 
-# define LIGHT_API LIGHT_VISIBILITY
+#ifdef _MSC_VER
+#define LIGHT_API __declspec(dllimport) LIGHT_VISIBILITY
+#else
+#define LIGHT_API LIGHT_VISIBILITY
 #endif
-
-#if 0
-#if defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 1)
-# ifdef _MSC_VER
-#   define LIGHT_API __declspec(dllexport) LIGHT_VISIBILITY
-# else 
-#   define LIGHT_API LIGHT_VISIBILITY
-# endif
-#elif defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 0)
-# ifdef _MSC_VER
-#   define LIGHT_API __declspec(dllimport) LIGHT_VISIBILITY
-# else 
-#   define LIGHT_API LIGHT_VISIBILITY
-# endif
-#else 
-#  define LIGHT_API LIGHT_VISIBILITY
-#endif
+#else
+#define LIGHT_API LIGHT_VISIBILITY
 #endif
 
 #endif /* INCLUDE_EXPORT_H_ */

--- a/include/light_export.h
+++ b/include/light_export.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 woidpointer@gmail.com
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef INCLUDE_EXPORT_H_
+#define INCLUDE_EXPORT_H_
+
+/* =====   LIGHT_API : control library symbols visibility   ===== */
+#ifndef LIGHT_VISIBILITY
+#  if defined(__GNUC__) && (__GNUC__ >= 4)
+#    define LIGHT_VISIBILITY __attribute__ ((visibility ("default")))
+#  else
+#    define LIGHT_VISIBILITY
+#  endif
+#endif
+
+/* API call convention*/
+#if WIN32
+#define LIGHT_API_CALL __stdcall
+#else
+#define LIGHT_API_CALL
+#endif
+
+#if defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 1)
+# ifdef _MSC_VER
+#   define LIGHT_API __declspec(dllexport) LIGHT_VISIBILITY
+# else 
+#   define LIGHT_API LIGHT_VISIBILITY
+# endif
+#elif defined LIGHT_IMPORTS && (LIGHT_IMPORTS == 1)
+# ifdef _MSC_VER
+#   define LIGHT_API __declspec(dllimport) LIGHT_VISIBILITY
+# else 
+#   define LIGHT_API LIGHT_VISIBILITY
+# endif
+#else 
+# define LIGHT_API LIGHT_VISIBILITY
+#endif
+
+#if 0
+#if defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 1)
+# ifdef _MSC_VER
+#   define LIGHT_API __declspec(dllexport) LIGHT_VISIBILITY
+# else 
+#   define LIGHT_API LIGHT_VISIBILITY
+# endif
+#elif defined LIGHT_EXPORTS && (LIGHT_EXPORTS == 0)
+# ifdef _MSC_VER
+#   define LIGHT_API __declspec(dllimport) LIGHT_VISIBILITY
+# else 
+#   define LIGHT_API LIGHT_VISIBILITY
+# endif
+#else 
+#  define LIGHT_API LIGHT_VISIBILITY
+#endif
+#endif
+
+#endif /* INCLUDE_EXPORT_H_ */

--- a/include/light_io.h
+++ b/include/light_io.h
@@ -22,17 +22,19 @@
 #ifndef INCLUDE_LIGHT_IO_H_
 #define INCLUDE_LIGHT_IO_H_
 
+#include "light_export.h"
+
 #include <stdio.h>
 
 typedef struct light_file_t* light_file;
 
-light_file light_io_open(const char* file_name, const char* mode);
+LIGHT_API light_file light_io_open(const char* file_name, const char* mode);
 
-size_t light_io_read(light_file fd, void* buf, size_t count);
-size_t light_io_write(light_file fd, const void* buf, size_t count);
+LIGHT_API size_t light_io_read(light_file fd, void* buf, size_t count);
+LIGHT_API size_t light_io_write(light_file fd, const void* buf, size_t count);
 
-int light_io_seek(light_file fd, long int offset, int origin);
-int light_io_flush(light_file fd);
-int light_io_close(light_file fd);
+LIGHT_API int light_io_seek(light_file fd, long int offset, int origin);
+LIGHT_API int light_io_flush(light_file fd);
+LIGHT_API int light_io_close(light_file fd);
 
 #endif /* INCLUDE_LIGHT_IO_H_ */

--- a/include/light_io_mem.h
+++ b/include/light_io_mem.h
@@ -22,9 +22,10 @@
 #ifndef INCLUDE_LIGHT_IO_MEM_H_
 #define INCLUDE_LIGHT_IO_MEM_H_
 
+#include "light_export.h"
 #include "light_io.h"
 #include <stdio.h>
 
-light_file light_io_mem_create(void* memory, size_t size);
+LIGHT_API light_file light_io_mem_create(void* memory, size_t size);
 
 #endif // INCLUDE_LIGHT_IO_MEM_H_

--- a/include/light_pcapng.h
+++ b/include/light_pcapng.h
@@ -89,23 +89,23 @@ extern "C" {
 
 	// Read next record out of file, if you give an existing record I will free it for you
 	// The returned record must be freed by either YOU or the next call to light_free_block!
-	void light_read_block(light_file fd, light_block* block, bool *swap_endianess);
+	LIGHT_API void light_read_block(light_file fd, light_block* block, bool *swap_endianess);
 
-	light_block light_create_block(uint32_t type, const uint32_t* body, uint32_t body_length);
+	LIGHT_API light_block light_create_block(uint32_t type, const uint32_t* body, uint32_t body_length);
 
-	void light_free_block(light_block pcapng);
+	LIGHT_API void light_free_block(light_block pcapng);
 
-	size_t light_write_block(light_file file, const light_block block);
+	LIGHT_API size_t light_write_block(light_file file, const light_block block);
 
 	// option functions
 
-	light_option light_create_option(const uint16_t option_code, const uint16_t option_length, const void* option_value);
-	void light_free_option(light_option option);
+	LIGHT_API light_option light_create_option(const uint16_t option_code, const uint16_t option_length, const void* option_value);
+	LIGHT_API void light_free_option(light_option option);
 
-	light_option light_find_option(const light_block block, uint16_t option_code);
+	LIGHT_API light_option light_find_option(const light_block block, uint16_t option_code);
 
-	int light_add_option(light_block section, light_block block, light_option option, bool copy);
-	int light_update_option(light_block section, light_block block, light_option option);
+	LIGHT_API int light_add_option(light_block section, light_block block, light_option option, bool copy);
+	LIGHT_API int light_update_option(light_block section, light_block block, light_option option);
 
 
 #ifdef __cplusplus

--- a/include/light_pcapng_ext.h
+++ b/include/light_pcapng_ext.h
@@ -26,6 +26,7 @@
 extern "C" {
 #endif
 
+#include "light_export.h"
 #include "light_io.h"
 #include <stddef.h>
 #include <stdint.h>
@@ -71,24 +72,24 @@ typedef struct light_file_info {
 } light_pcapng_file_info;
 
 
-light_pcapng light_pcapng_open(const char* file_path, const char* mode);
-light_pcapng light_pcapng_create(light_file file, const char* mode, light_pcapng_file_info* info);
+LIGHT_API light_pcapng light_pcapng_open(const char* file_path, const char* mode);
+LIGHT_API light_pcapng light_pcapng_create(light_file file, const char* mode, light_pcapng_file_info* info);
 
-light_pcapng_file_info *light_create_default_file_info();
+LIGHT_API light_pcapng_file_info *light_create_default_file_info();
 
-light_pcapng_file_info *light_create_file_info(const char *os_desc, const char *hardware_desc, const char *app_desc, const char *comment);
+LIGHT_API light_pcapng_file_info *light_create_file_info(const char *os_desc, const char *hardware_desc, const char *app_desc, const char *comment);
 
-void light_free_file_info(light_pcapng_file_info *info);
+LIGHT_API void light_free_file_info(light_pcapng_file_info *info);
 
-light_pcapng_file_info *light_pcang_get_file_info(light_pcapng pcapng);
+LIGHT_API light_pcapng_file_info *light_pcang_get_file_info(light_pcapng pcapng);
 
-int light_read_packet(light_pcapng pcapng, light_packet_interface* packet_interface, light_packet_header *packet_header, const uint8_t **packet_data);
+LIGHT_API int light_read_packet(light_pcapng pcapng, light_packet_interface* packet_interface, light_packet_header *packet_header, const uint8_t **packet_data);
 
-int light_write_packet(light_pcapng pcapng, const light_packet_interface* packet_interface, const light_packet_header *packet_header, const uint8_t *packet_data);
+LIGHT_API int light_write_packet(light_pcapng pcapng, const light_packet_interface* packet_interface, const light_packet_header *packet_header, const uint8_t *packet_data);
 
-int light_pcapng_close(light_pcapng pcapng);
+LIGHT_API int light_pcapng_close(light_pcapng pcapng);
 
-int light_pcapng_flush(light_pcapng pcapng);
+LIGHT_API int light_pcapng_flush(light_pcapng pcapng);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,9 +15,9 @@ endif()
 
 foreach(test_file ${LIGHT_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
-        
+
     add_executable(${test_name} ${test_file})
-    target_link_libraries(${test_name} light_pcapng_static)
+    target_link_libraries(${test_name} light_pcapng)
 endforeach()
 
 foreach(sample ${samples_pcapng} ${samples_zsts})
@@ -25,29 +25,29 @@ foreach(sample ${samples_pcapng} ${samples_zsts})
     string(REPLACE "." "_" param ${param})
     add_test(
         NAME "blocks.dump.${param}"
-        COMMAND test_blocks_dump 
-            ${sample} 
+        COMMAND test_blocks_dump
+            ${sample}
             "${CMAKE_CURRENT_LIST_DIR}/results/blocks.dump.${param}.txt"
     )
     add_test(
         NAME "packets.dump.${param}"
-        COMMAND test_packets_dump 
-            ${sample} 
+        COMMAND test_packets_dump
+            ${sample}
             "${CMAKE_CURRENT_LIST_DIR}/results/packets.dump.${param}.txt"
     )
 endforeach()
 
 add_test(
     NAME "blocks.merge.merge"
-    COMMAND test_blocks_merge 
-        "${CMAKE_CURRENT_LIST_DIR}/results/blocks.merged.pcapng" 
+    COMMAND test_blocks_merge
+        "${CMAKE_CURRENT_LIST_DIR}/results/blocks.merged.pcapng"
         ${samples_pcapng}
 )
 
 add_test(
     NAME "packets.merge.merge"
-    COMMAND test_packets_merge 
-        "${CMAKE_CURRENT_LIST_DIR}/results/packets.merged.pcapng" 
+    COMMAND test_packets_merge
+        "${CMAKE_CURRENT_LIST_DIR}/results/packets.merged.pcapng"
         ${samples_pcapng}
 )
 

--- a/tests/test_io_mem.c
+++ b/tests/test_io_mem.c
@@ -53,6 +53,7 @@ int read_file(const char* file, uint8_t** data, size_t* size)
 }
 
 int main(int argc, const char** args) {
+
 	if (argc != 2) {
 		fprintf(stderr, "Usage %s [infile]", args[0]);
 		return 1;


### PR DESCRIPTION
Exported explicitly API interfaces (DLL/shared object)
Static and shared library created can be controlled by cmake  BUILD_SHARED_LIBS variable
Changed zstd dependency handling to use either the downloaded version or the version which is found by cmake.
